### PR TITLE
Add plan performance functionality

### DIFF
--- a/core/deps.py
+++ b/core/deps.py
@@ -5,9 +5,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.connection import get_async_session
 from services.plan_insert_service import PlanService
+from services.plan_performance_service import PlanPerformanceService
 
 
 async def get_plan_insert_service(
     session: AsyncSession = Depends(get_async_session),
 ) -> AsyncGenerator[PlanService, None]:
     yield PlanService(session)
+
+
+async def get_plan_performance_service(
+    session: AsyncSession = Depends(get_async_session),
+) -> AsyncGenerator[PlanPerformanceService, None]:
+    yield PlanPerformanceService(session)

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 
 from routers.health_check_router import health_check_router
 from routers.plan_insert_router import load_data_rout
+from routers.plan_performance_router import plan_perf_rout
 
 from routers.user_credits_rout import user_credits
 
@@ -18,6 +19,7 @@ def create_app() -> FastAPI:
     app.include_router(load_data_rout)
 
     app.include_router(user_credits)
+    app.include_router(plan_perf_rout)
 
     return app
 

--- a/repo/plan_insert_repo.py
+++ b/repo/plan_insert_repo.py
@@ -1,11 +1,18 @@
+import calendar
+from datetime import date
+from decimal import Decimal
 from typing import Sequence
 
+from sqlalchemy import select, Row, Date, func, and_
 
 from sqlalchemy import select, Row, Date
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from db import Plan
+from db import Plan, Dictionary
 from sqlalchemy import tuple_
+
+from db.credits_model import Credit
+from db.payments_model import Payment
 
 
 class PlanRepo:
@@ -26,3 +33,41 @@ class PlanRepo:
         self.session.add_all(plans)
         await self.session.commit()
         return plans
+
+    async def get_actual_sum(
+        self, category: str, period_start: date, period_to: date
+    ) -> Decimal:
+
+        if category.lower() == "видача":
+            credit_q = select(func.coalesce(func.sum(Credit.body), 0)).where(
+                and_(
+                    Credit.issuance_date >= period_start,
+                    Credit.issuance_date <= period_to,
+                )
+            )
+            credit_res = await self.session.execute(credit_q)
+            return Decimal(credit_res.scalar() or 0)
+        elif category.lower() == "збір":
+            payment_q = select(func.coalesce(func.sum(Payment.sum), 0)).where(
+                and_(
+                    Payment.payment_date >= period_start,
+                    Payment.payment_date <= period_to,
+                )
+            )
+            payment_res = await self.session.execute(payment_q)
+            return Decimal(payment_res.scalar() or 0)
+        return Decimal(0)
+
+    async def get_plans_for_period(self, period: date):
+        result = await self.session.execute(
+            select(
+                Plan.id,
+                Plan.period,
+                Plan.sum,
+                Dictionary.name.label("category"),
+                Plan.category_id,
+            )
+            .join(Dictionary, Plan.category_id == Dictionary.id)
+            .where(Plan.period == period.replace(day=1))
+        )
+        return result.fetchall()

--- a/routers/plan_insert_router.py
+++ b/routers/plan_insert_router.py
@@ -9,24 +9,26 @@ from core.deps import get_plan_insert_service
 
 from services.plan_insert_service import PlanService
 
-load_data_rout = APIRouter(tags=["Plan load"], prefix="/plans_insert")
+load_data_rout = APIRouter(
+    tags=["Plan"],
+)
 
 
 @load_data_rout.post(
-    "",
+    "/plans_insert",
     status_code=status.HTTP_200_OK,
     summary="Upload file with plan data",
     description="""
 Uploads an Excel file with plans for a new month <br>
 The file must contain the following columns:
-- *Mісяць плану*: date with the first day of the target month (e.g., 2025-09-01)
-- *Назва категорії плану* : (e.g. видача/збір)
-- *Суьф*: a non-empty numeric value (zero is allowed, but empty/negatives are not)
+- `Mісяць плану`: date with the first day of the target month (e.g., 2025-09-01)
+- `Назва категорії плану` : (e.g. видача/збір)
+- `Сума`: a non-empty numeric value (zero is allowed, but empty/negatives are not)
 """,
 )
 async def plans_insert(
     plan_service: Annotated[PlanService, Depends(get_plan_insert_service)],
     file: UploadFile,
 ):
-    await plan_service.load_file(file.file)
-    return JSONResponse({"detail": "Plans have been successfully uploaded"})
+
+    return await plan_service.load_file(file.file)

--- a/routers/plan_performance_router.py
+++ b/routers/plan_performance_router.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Depends
+from datetime import date
+from typing import List, Annotated
+
+from starlette import status
+
+from services.plan_performance_service import PlanPerformanceService
+
+from core.deps import get_plan_performance_service
+
+from schemas.plan_performance_schema import PlanPerformanceResponse
+
+
+plan_perf_rout = APIRouter(tags=["Plan"])
+
+
+@plan_perf_rout.get(
+    "/plans_performance",
+    status_code=status.HTTP_200_OK,
+    summary="Get plans performance",
+    description="Get information about the implementation of plans for a specific date<br>"
+    "The target date must be in the format: `YYYY-MM-DD`",
+    response_model=List[PlanPerformanceResponse],
+)
+async def get_plans_performance(
+    target_date: date,
+    plan_perf_service: Annotated[
+        PlanPerformanceService, Depends(get_plan_performance_service)
+    ],
+):
+    return await plan_perf_service.get_performance(target_date)

--- a/schemas/plan_performance_schema.py
+++ b/schemas/plan_performance_schema.py
@@ -1,0 +1,12 @@
+from datetime import date
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class PlanPerformanceResponse(BaseModel):
+    period: date
+    category: str
+    plan_sum: Decimal
+    fact_sum: Decimal
+    percent: float

--- a/services/plan_performance_service.py
+++ b/services/plan_performance_service.py
@@ -1,0 +1,36 @@
+import calendar
+from datetime import date
+
+from repo.plan_insert_repo import PlanRepo
+
+
+class PlanPerformanceService:
+    def __init__(self, session):
+        self.repo = PlanRepo(session)
+
+    async def get_performance(self, target_date: date):
+
+        plans = await self.repo.get_plans_for_period(target_date)
+        data = []
+        for plan in plans:
+            period_start = plan.period.replace(day=1)
+            last_day = plan.period.replace(
+                day=calendar.monthrange(plan.period.year, plan.period.month)[1]
+            )
+            period_to = min(last_day, target_date)
+
+            actual_sum = await self.repo.get_actual_sum(
+                plan.category, period_start, period_to
+            )
+            percent = float(actual_sum) / float(plan.sum) * 100 if plan.sum else 0.0
+
+            data.append(
+                dict(
+                    period=str(plan.period),
+                    category=plan.category,
+                    plan_sum=plan.sum,
+                    fact_sum=actual_sum,
+                    percent=round(percent, 2),
+                )
+            )
+        return data


### PR DESCRIPTION
- Introduce a new FastAPI route `/plans_performance` for retrieving performance details of plans for a given date.
- Implement `PlanPerformanceService` and update `PlanRepo` for fetching plan performance data and calculating execution percentages.
- Add `plan_performance_schema.py` for Pydantic models (`PlanPerformanceResponse`).
- Include dependency injection for `PlanPerformanceService` using `get_plan_performance_service`.