### PR TITLE
Add year performance route and enhance data loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,5 @@ endif
 
 migrate: run_app ## Apply migrations
 	docker compose exec app alembic upgrade head
+load_data: ## Load all data to db
+	docker exec -it data-factory-api python -m loader.data_loader

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Firstly, you need to have [Docker](https://docs.docker.com/get-docker/) installe
 - Apply migrations:
 
       make migrate
+- Load test data:
+
+      make load_test_data
 
 ## Interactive API docs:
 

--- a/loader/data_loader.py
+++ b/loader/data_loader.py
@@ -1,7 +1,8 @@
 import pandas as pd
-from typing import List, Any, Dict
+from typing import List, Type, Callable, Any
 import asyncio
 from sqlalchemy import select
+from db.connection import async_session_maker
 from db.users_model import User
 from db.credits_model import Credit
 from db.dictionary_model import Dictionary
@@ -11,113 +12,139 @@ from logs.config.logging_config import logger
 
 
 class DataLoader:
-    def __init__(self, session_maker):
-        self.session_maker = session_maker
+    @staticmethod
+    def parse_dates(series: pd.Series, date_format: str = "%d.%m.%Y") -> pd.Series:
+        try:
+            parsed = pd.to_datetime(series, format=date_format, errors="coerce")
+            return parsed.dt.date.where(series.notnull(), None)
+        except Exception as e:
+            logger.error(f"Failed to parse dates: {e}")
+            raise
 
     @staticmethod
-    def _parse_dates(series: pd.Series, date_format: str = "%d.%m.%Y") -> pd.Series:
-        return pd.to_datetime(
-            series, format=date_format, errors="coerce"
-        ).dt.date.where(series.notnull(), None)
+    async def read_csv_async(filename: str, sep: str = "\t") -> pd.DataFrame:
+        try:
+            return await asyncio.to_thread(pd.read_csv, filename, sep=sep)
+        except Exception as e:
+            logger.error(f"Failed to load CSV file {filename}: {e}")
+            raise
 
-    async def _read_csv_async(self, filename: str, sep: str = "\t") -> pd.DataFrame:
-
-        return await asyncio.to_thread(pd.read_csv, filename, sep=sep)
-
-    def _get_columns_map(self, model_cls: Any) -> Dict[str, str]:
-
-        if model_cls.__name__ == "Dictionary":
-            return {"id": "id", "name": "name"}
-        if model_cls.__name__ == "User":
-            return {
-                "id": "id",
-                "login": "login",
-                "registration_date": "registration_date",
-            }
-        if model_cls.__name__ == "Plan":
-            return {
-                "id": "id",
-                "period": "period",
-                "sum": "sum",
-                "category_id": "category_id",
-            }
-        if model_cls.__name__ == "Credit":
-            return {
-                "id": "id",
-                "user_id": "user_id",
-                "issuance_date": "issuance_date",
-                "return_date": "return_date",
-                "actual_return_date": "actual_return_date",
-                "body": "body",
-                "percent": "percent",
-            }
-        if model_cls.__name__ == "Payment":
-            return {
-                "id": "id",
-                "sum": "sum",
-                "payment_date": "payment_date",
-                "credit_id": "credit_id",
-                "type_id": "type_id",
-            }
-        raise ValueError(f"Unknown model: {model_cls.__name__}")
-
-    async def _load_data(self, filename: str, model_cls: Any) -> List[Any]:
-        df = await self._read_csv_async(filename)
-        columns_map = self._get_columns_map(model_cls)
-
-        for csv_col, model_attr in columns_map.items():
-            if "date" in model_attr:
-                df[csv_col] = self._parse_dates(df[csv_col])
-
+    async def load_dictionaries(self, filename: str) -> List[Dictionary]:
+        df = await self.read_csv_async(filename)
         return [
-            model_cls(
-                **{
-                    model_attr: row[csv_col]
-                    for csv_col, model_attr in columns_map.items()
-                }
+            Dictionary(id=int(row["id"]), name=row["name"]) for _, row in df.iterrows()
+        ]
+
+    async def load_users(self, filename: str) -> List[User]:
+
+        df = await self.read_csv_async(filename)
+        df["registration_date"] = self.parse_dates(df["registration_date"])
+        return [
+            User(
+                id=int(row["id"]),
+                login=row["login"],
+                registration_date=row["registration_date"],
             )
             for _, row in df.iterrows()
         ]
 
-    async def import_all(self) -> None:
+    async def load_plans(self, filename: str) -> List[Plan]:
 
-        tables_to_import = [
-            {
-                "model": Dictionary,
-                "filename": "test_data/dictionary.csv",
-                "name": "dictionaries",
-            },
-            {"model": User, "filename": "test_data/users.csv", "name": "users"},
-            {"model": Plan, "filename": "test_data/plans.csv", "name": "plans"},
-            {"model": Credit, "filename": "test_data/credits.csv", "name": "credits"},
-            {
-                "model": Payment,
-                "filename": "test_data/payments.csv",
-                "name": "payments",
-            },
+        df = await self.read_csv_async(filename)
+        df["period"] = self.parse_dates(df["period"])
+        return [
+            Plan(
+                id=int(row["id"]),
+                period=row["period"],
+                sum=row["sum"],
+                category_id=row["category_id"],
+            )
+            for _, row in df.iterrows()
         ]
 
-        async with self.session_maker() as session:
-            for table_info in tables_to_import:
-                model = table_info["model"]
-                filename = table_info["filename"]
-                name = table_info["name"]
+    async def load_credits(self, filename: str) -> List[Credit]:
 
-                try:
+        df = await self.read_csv_async(filename)
+        for col in ["issuance_date", "return_date", "actual_return_date"]:
+            df[col] = self.parse_dates(df[col])
+        return [
+            Credit(
+                id=int(row["id"]),
+                user_id=row["user_id"],
+                issuance_date=row["issuance_date"],
+                return_date=row["return_date"],
+                actual_return_date=row["actual_return_date"],
+                body=row["body"],
+                percent=row["percent"],
+            )
+            for _, row in df.iterrows()
+        ]
 
-                    result = await session.execute(select(model.id))
-                    existing_ids = {row[0] for row in result.all()}
+    async def load_payments(self, filename: str) -> List[Payment]:
 
-                    all_objs = await self._load_data(filename, model)
-                    new_objs = [obj for obj in all_objs if obj.id not in existing_ids]
+        df = await self.read_csv_async(filename)
+        df["payment_date"] = self.parse_dates(df["payment_date"])
+        return [
+            Payment(
+                id=int(row["id"]),
+                sum=row["sum"],
+                payment_date=row["payment_date"],
+                credit_id=row["credit_id"],
+                type_id=row["type_id"],
+            )
+            for _, row in df.iterrows()
+        ]
 
-                    if new_objs:
-                        session.add_all(new_objs)
-                        logger.info(f"Imported {len(new_objs)} new {name}.")
-                    else:
-                        logger.warning(f"All {name} already exist in the database.")
+    async def _import_data(
+        self,
+        session,
+        model_cls: Type,
+        csv_loader: Callable[[str], Any],
+        filename: str,
+        log_label: str,
+        id_field: str = "id",
+    ):
 
-                except Exception as e:
-                    logger.error(f"Error importing {name}: {e}")
+        result = await session.execute(select(getattr(model_cls, id_field)))
+        existing_ids = {row[0] for row in result.all()}
+        objs = await csv_loader(filename)
+        new_objs = [obj for obj in objs if getattr(obj, id_field) not in existing_ids]
 
+        if new_objs:
+            session.add_all(new_objs)
+            logger.info(f"Imported {len(new_objs)} {log_label}.")
+        else:
+            logger.warning(f"{log_label.capitalize()} already up-to-date.")
+
+    async def import_all(self) -> None:
+
+        async with async_session_maker() as session:
+            await self._import_data(
+                session,
+                Dictionary,
+                self.load_dictionaries,
+                "test_data/dictionary.csv",
+                "dictionaries",
+            )
+            await self._import_data(
+                session, User, self.load_users, "test_data/users.csv", "users"
+            )
+            await self._import_data(
+                session, Plan, self.load_plans, "test_data/plans.csv", "plans"
+            )
+            await self._import_data(
+                session, Credit, self.load_credits, "test_data/credits.csv", "credits"
+            )
+            await self._import_data(
+                session,
+                Payment,
+                self.load_payments,
+                "test_data/payments.csv",
+                "payments",
+            )
             await session.commit()
+
+
+if __name__ == "__main__":
+    loader = DataLoader()
+    asyncio.run(loader.import_all())

--- a/main.py
+++ b/main.py
@@ -1,24 +1,11 @@
-from contextlib import asynccontextmanager
-
 from fastapi import FastAPI
 
-from db.connection import async_session_maker
-from loader.data_loader import DataLoader
-from logs.config.logging_config import logger
+
 from routers.health_check_router import health_check_router
 from routers.plan_insert_router import load_data_rout
 from routers.plan_performance_router import plan_perf_rout
 from routers.user_credits_rout import user_credits
-from routers.year_perfmance_router import year_performance_router
-
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    logger.info("Starting application: beginning data import...")
-    loader = DataLoader(session_maker=async_session_maker)
-    await loader.import_all()
-    logger.info("Data import completed. Application startup finished.")
-    yield
+from routers.year_performance_router import year_performance_router
 
 
 def create_app() -> FastAPI:
@@ -27,7 +14,6 @@ def create_app() -> FastAPI:
         docs_url="/docs",
         description="Data Factory test task",
         debug=True,
-        lifespan=lifespan,
     )
     app.include_router(health_check_router)
     app.include_router(load_data_rout)

--- a/routers/year_performance_router.py
+++ b/routers/year_performance_router.py
@@ -1,0 +1,32 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+
+from core.deps import get_year_performance_service
+
+
+from schemas.plan_performance_schema import YearPerformanceResponse
+
+
+year_performance_router = APIRouter(tags=["Plan"])
+
+
+@year_performance_router.get(
+    "/year_performance",
+    summary="Get year performance by year",
+    response_model=list[YearPerformanceResponse],
+    description="Get information about the performance of plans for a specific year<br>"
+    "The target year must be in the format: `YYYY`",
+)
+async def get_year_performance(
+    target_year: int,
+    year_perf_service: Annotated[
+        YearPerformanceResponse, Depends(get_year_performance_service)
+    ],
+    limit: int = 12,
+    offset: int = 0,
+):
+    return await year_perf_service.get_year_performance(
+        target_year, limit=limit, offset=offset
+    )


### PR DESCRIPTION
- Introduce `/year_performance` route to fetch yearly plan performance.
- Refactor `DataLoader` for modular loading logic and error handling.
- Remove `lifespan` from app setup; streamline startup process.